### PR TITLE
Auto-set darkMode to OS / User Agent setting

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -123,7 +123,7 @@ function App() {
     setInfoModalIsOpen(false)
   }
 
-  const [darkMode, setDarkMode] = useLocalStorage('dark-mode', false)
+  const [darkMode, setDarkMode] = useLocalStorage('dark-mode', window.matchMedia('(prefers-color-scheme: dark)').matches)
   const toggleDarkMode = () => {
     setDarkMode((prev) => !prev)
   }


### PR DESCRIPTION
- Initialize `darkMode` via `prefers-color-scheme`
  - This will not override the user's existing `dark-mode` setting