### PR TITLE
Fixed the Contributing ReadMe Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ After submitting a guess, the letters will turn gray, green, or yellow.
 
 Feel free to open an issue for any bugs or feature requests.
 
-To contribute to the code, see [CONTRIBUTING.md](https://github.com/octokatherine/word-master/blob/main/CONTRIBUTING.md)
+To contribute to the code, see [CONTRIBUTING.md](https://github.com/DevangThakkar/wordle_archive/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
Earlier the link directed to another repositories contribution guidelines. Redirected it to this repositories Contributing doc.