### PR TITLE
docs: Fix the CONTRIBUTING link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ After submitting a guess, the letters will turn gray, green, or yellow.
 
 Feel free to open an issue for any bugs or feature requests.
 
-To contribute to the code, see [CONTRIBUTING.md](https://github.com/octokatherine/word-master/blob/main/CONTRIBUTING.md)
+To contribute to the code, see [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
This was an absolute link, and to the wrong repo.  Now it's a relative link, so it will always go to the local file in whatever repo (fork, etc).

Closes #53